### PR TITLE
Fix compilation warning

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,11 @@
 site_name: 'St. Jude Cloud Documentation'
 theme:
   name: 'material'
+  custom_dir: 'mkdocs-material/material'
   logo: 'images/stjude-logo-child-white.png'
   font:
       text: 'Ubuntu'
       code: 'Ubuntu Mono'
-theme_dir: 'mkdocs-material/material'
 
 extra_css:
   - css/extra.css


### PR DESCRIPTION
Fixes the following compilation warning:

    WARNING -  Config value: 'theme_dir'. Warning: The configuration
    option {0} has been deprecated and will be removed in a future
    release of MkDocs.

See <https://www.mkdocs.org/about/release-notes/#theme_dir-configuration-option-fully-deprecated>.