### PR TITLE
Update data transfer app guide to read 'guide not complete'.

### DIFF
--- a/docs/guides/data/data-transfer-app.md
+++ b/docs/guides/data/data-transfer-app.md
@@ -1,12 +1,12 @@
-The St. Jude Cloud data transfer application is still under development.
-Please refer to the [command line interaction guide](command-line.md) for the official 
-documentation on how to upload data to or download download data from St. Jude Cloud
-Platform.
+!!! note
+    We consider the St. Jude Cloud data transfer application to be production ready.
+    However, we have not yet completed the guide on how to use it. This guide will likely be
+    completed soon. In the meantime, we hope that you will try to use the app and let us
+    know your feedback at our [contact us form](https://stjude.cloud/contact).
 
-If you are adventurous, we welcome you to try out the experience by
-[downloading the latest release](https://dta.stjude.cloud) and letting
-us know how it goes! You can find the source code
-[here](https://github.com/stjude/sjcloud-data-transfer-app). If you
+You can [click here](https://dta.stjude.cloud) to download the latest release of the
+St. Jude Cloud data transfer application. If you are interested in viewing the source code, 
+you can do so [here](https://github.com/stjude/sjcloud-data-transfer-app). If you
 would like to file an issue you are experiencing with the application,
-you can do so
-[here](https://github.com/stjude/sjcloud-data-transfer-app/issues).
+you can do so [here](https://github.com/stjude/sjcloud-data-transfer-app/issues).
+For users looking to upload/download files on the command line, please refer to the [command line interaction guide](command-line.md).


### PR DESCRIPTION
The DTA is ready for prime-time, we just haven't written the guide to use it yet. I've updated the documentation to reflect that.