### PR TITLE
cis-x: Add input for candidate FPKM threshold

### DIFF
--- a/docs/guides/tools/cis-x.md
+++ b/docs/guides/tools/cis-x.md
@@ -41,7 +41,7 @@ cis-X currently only works with hg19 (GRCh37).
 | [Somatic CNVs]               | File      | Tab-delimited file containing copy number aberrations in the tumor genome                       | *.txt          |
 | CNV/LOH action               | String    | The behavior when handling markers in CNV/LOH regions. Can be either `keep` or `drop`.          | drop           |
 | Minimum coverage for WGS     | Integer   | The minimum coverage in WGS to be included in the analysis                                      | 10             |
-| Minimum coverage for RNA-seq | Integer   | The minimum coverage in RNA-seq to be included in the analysis                                  | 10             |
+| Minimum coverage for RNA-seq | Integer   | The minimum coverage in RNA-seq to be included in the analysis                                  | 5              |
 | Candidate FPKM threshold     | Float     | The FPKM threshold for the nomination of a cis-activated candidate                              | 0.1            |
 
 [Single nucleotide variants]: #single-nucleotide-variants

--- a/docs/guides/tools/cis-x.md
+++ b/docs/guides/tools/cis-x.md
@@ -29,8 +29,8 @@ cis-X currently only works with hg19 (GRCh37).
 
 | Name                         | Type      | Description                                                                                     | Example        |
 |------------------------------|-----------|-------------------------------------------------------------------------------------------------|----------------|
-| Sample ID                    | Parameter | The ID of the input sample                                                                      | SJALL018373_D1 |
-| Disease subtype              | Parameter | The disease name under analysis. Must be either TALL or AML.                                   | TALL           |
+| Sample ID                    | String    | The ID of the input sample                                                                      | SJALL018373_D1 |
+| Disease subtype              | String    | The disease name under analysis. Must be either TALL or AML.                                    | TALL           |
 | [Single nucleotide variants] | File      | Tab-delimited file containing raw sequence variants                                             | *.txt          |
 | [CNV/LOH regions]            | File      | Tab-delimited file containing any aneuploidy region existing in the tumor genome under analysis | *.txt          |
 | RNA-seq BAM                  | File      | BAM file aligned to hg19 (GRCh37)                                                               | *.bam          |

--- a/docs/guides/tools/cis-x.md
+++ b/docs/guides/tools/cis-x.md
@@ -42,6 +42,7 @@ cis-X currently only works with hg19 (GRCh37).
 | CNV/LOH action               | String    | The behavior when handling markers in CNV/LOH regions. Can be either `keep` or `drop`.          | drop           |
 | Minimum coverage for WGS     | Integer   | The minimum coverage in WGS to be included in the analysis                                      | 10             |
 | Minimum coverage for RNA-seq | Integer   | The minimum coverage in RNA-seq to be included in the analysis                                  | 10             |
+| Candidate FPKM threshold     | Float     | The FPKM threshold for the nomination of a cis-activated candidate                              | 0.1            |
 
 [Single nucleotide variants]: #single-nucleotide-variants
 [CNV/LOH regions]: #cnvloh-regions


### PR DESCRIPTION
This argument was added in https://github.com/stjude/cis-x/commit/9c2160954d5bc9ee66b05c0f7a31ccb1238de9c5 (cis-X 1.2.0). The default values come from https://github.com/stjude/cis-x/commit/3861d99bf69ef7fbdb97c2b9bd7714239374a88a.