### PR TITLE
Fix broken reference to renamed modernizr.js file

### DIFF
--- a/mkdocs-material/material/base.html
+++ b/mkdocs-material/material/base.html
@@ -64,7 +64,7 @@
       {% endif %}
     {% endblock %}
     {% block libs %}
-      <script src="{{ base_url }}/assets/javascripts/modernizr.js"></script>
+      <script src="{{ base_url }}/assets/javascripts/modernizr.20ef595d.js"></script>
 
       <!-- Adobe Analytics -->
       <script src="//assets.adobedtm.com/launch-EN942f79c83ff84c10a45b4856a85eaccb.min.js" async></script>


### PR DESCRIPTION
This PR fixes the broken reference to `modernizr.js` which was throwing errors in the console when visiting the documentation.

`base.html` in the `mkdocs-material` folder was still referencing the old `modernizr.js` file which was deleted/renamed. This just fixes that reference.