### PR TITLE
Fix broken references and spellcheck

### DIFF
--- a/docs/create-an-account.md
+++ b/docs/create-an-account.md
@@ -12,7 +12,7 @@ In order to request St. Jude data and work with that data in the cloud, you will
 
 If you work at an institution that is not St. Jude (the standard case), you can use the following process to create an account:
 
-1. Go to the [DNAnexus log in page](https://platform.dnanexus.com/login).
+1. Go to the [DNAnexus log in page](https://platform.dnanexus.com/login?client_id=sjcloudplatform).
 2. Click "Create an Account".
 3. Fill in your information.
 4. On the Create New Account page, make sure to select "Microsoft Azure (westus)" as the Default Cloud Region.
@@ -22,7 +22,7 @@ If you work at an institution that is not St. Jude (the standard case), you can 
 
 ### Logging in
 
-Simply go to the [DNAnexus log in page](https://platform.dnanexus.com/login), enter the username and password that you registered with from the preceding section, and click 'LOG IN'.
+Simply go to the [DNAnexus log in page](https://platform.dnanexus.com/login?client_id=sjcloudplatform), enter the username and password that you registered with from the preceding section, and click 'LOG IN'.
 
 ### Lab billing setup
 1. Click on the drop down next to your user name in the far right of the DNAnexus navigation bar, and select 'Profile'.
@@ -47,7 +47,7 @@ If you are a St. Jude user, you can log in using the following process:
 Internal users log in to St. Jude Cloud through the [internal DNAnexus login page](https://cloud.stjude.org). Simply enter your St. Jude credentials and click 'Submit'. This will redirect you to your Projects page on DNAnexus.
 
 !!! note
-    If you are unable to log in at this link, it probably means you have already set up a DNAnexus account through the [DNANexus log in page](https://platform.dnanexus.com/login) using your St. Jude email address. In this case, a DNAnexus account is already linked to your St. Jude email. To continue using this account, you will need to log in through the [DNAnexus log in page](https://platform.dnanexus.com/login).
+    If you are unable to log in at this link, it probably means you have already set up a DNAnexus account through the [DNANexus log in page](https://platform.dnanexus.com/login?client_id=sjcloudplatform) using your St. Jude email address. In this case, a DNAnexus account is already linked to your St. Jude email. To continue using this account, you will need to log in through the [DNAnexus log in page](https://platform.dnanexus.com/login?client_id=sjcloudplatform).
 
 ### Lab billing setup
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,4 +1,3 @@
-
 #### Will I be charged for using St. Jude Cloud?
 
 Any copy of the St. Jude data you receive is considered "sponsored",

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,11 +2,11 @@
 
 A St. Jude Cloud **Data Access Agreement (DAA)** is a legally binding document outlining a number of terms and conditions to which anyone working with St. Jude Cloud data must agree.
 We do not negotiate the terms of this document unless terms are found to be in conflict with the institution's state law. Filling out the Data Access Agreement carefully and completely is crucial to having your request approved promptly.
-[Click Here](../guides/forms/how-to-fill-out-DAA) for a step by step guide on how to fill out the DAA.
+[Click Here](./guides/forms/how-to-fill-out-DAA) for a step by step guide on how to fill out the DAA.
 
-If you have incompletely or incorrectly filled out your DAA and would like to upload a revised form, [Click Here](../guides/forms/how-to-fill-out-DAA#uploading-a-revised-daa) for instructions.
+If you have incompletely or incorrectly filled out your DAA and would like to upload a revised form, [Click Here](./guides/forms/how-to-fill-out-DAA#uploading-a-revised-daa) for instructions.
 
-Once you have submitted a correctly filled out DAA and have been granted access to one or more [Data Access Units (DAUs)](#data-access-unit), you can continue checking out files from those DAUs until your access expires. Access is generally granted for 1 year, at which point you must submit an Extension Addendum to continue using the data. [Click Here](../guides/forms/how-to-fill-out-Extension) for a step-by-step guide on how to fill out the Extension Addendum.
+Once you have submitted a correctly filled out DAA and have been granted access to one or more [Data Access Units (DAUs)](#data-access-unit), you can continue checking out files from those DAUs until your access expires. Access is generally granted for 1 year, at which point you must submit an Extension Addendum to continue using the data. [Click Here](./guides/forms/how-to-fill-out-Extension) for a step-by-step guide on how to fill out the Extension Addendum.
 
 ### Data Access Committee
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,11 +2,11 @@
 
 A St. Jude Cloud **Data Access Agreement (DAA)** is a legally binding document outlining a number of terms and conditions to which anyone working with St. Jude Cloud data must agree.
 We do not negotiate the terms of this document unless terms are found to be in conflict with the institution's state law. Filling out the Data Access Agreement carefully and completely is crucial to having your request approved promptly.
-[Click Here](./guides/forms/how-to-fill-out-DAA) for a step by step guide on how to fill out the DAA.
+[Click Here](../guides/forms/how-to-fill-out-DAA) for a step by step guide on how to fill out the DAA.
 
-If you have incompletely or incorrectly filled out your DAA and would like to upload a revised form, [Click Here](./guides/forms/how-to-fill-out-DAA#uploading-a-revised-daa) for instructions.
+If you have incompletely or incorrectly filled out your DAA and would like to upload a revised form, [Click Here](../guides/forms/how-to-fill-out-DAA#uploading-a-revised-daa) for instructions.
 
-Once you have submitted a correctly filled out DAA and have been granted access to one or more [Data Access Units (DAUs)](#data-access-unit), you can continue checking out files from those DAUs until your access expires. Access is generally granted for 1 year, at which point you must submit an Extension Addendum to continue using the data. [Click Here](./guides/forms/how-to-fill-out-Extension) for a step-by-step guide on how to fill out the Extension Addendum.
+Once you have submitted a correctly filled out DAA and have been granted access to one or more [Data Access Units (DAUs)](#data-access-unit), you can continue checking out files from those DAUs until your access expires. Access is generally granted for 1 year, at which point you must submit an Extension Addendum to continue using the data. [Click Here](../guides/forms/how-to-fill-out-Extension) for a step-by-step guide on how to fill out the Extension Addendum.
 
 ### Data Access Committee
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,11 +2,11 @@
 
 A St. Jude Cloud **Data Access Agreement (DAA)** is a legally binding document outlining a number of terms and conditions to which anyone working with St. Jude Cloud data must agree.
 We do not negotiate the terms of this document unless terms are found to be in conflict with the institution's state law. Filling out the Data Access Agreement carefully and completely is crucial to having your request approved promptly.
-[Click Here](../../guides/forms/how-to-fill-out-DAA) for a step by step guide on how to fill out the DAA.
+[Click Here](./guides/forms/how-to-fill-out-DAA) for a step by step guide on how to fill out the DAA.
 
-If you have incompletely or incorrectly filled out your DAA and would like to upload a revised form, [Click Here](../../guides/forms/how-to-fill-out-DAA#uploading-a-revised-daa) for instructions.
+If you have incompletely or incorrectly filled out your DAA and would like to upload a revised form, [Click Here](./guides/forms/how-to-fill-out-DAA#uploading-a-revised-daa) for instructions.
 
-Once you have submitted a correctly filled out DAA and have been granted access to one or more [Data Access Units (DAUs)](#data-access-unit), you can continue checking out files from those DAUs until your access expires. Access is generally granted for 1 year, at which point you must submit an Extension Addendum to continue using the data. [Click Here](../../guides/forms/how-to-fill-out-Extension) for a step-by-step guide on how to fill out the Extension Addendum.
+Once you have submitted a correctly filled out DAA and have been granted access to one or more [Data Access Units (DAUs)](#data-access-unit), you can continue checking out files from those DAUs until your access expires. Access is generally granted for 1 year, at which point you must submit an Extension Addendum to continue using the data. [Click Here](./guides/forms/how-to-fill-out-Extension) for a step-by-step guide on how to fill out the Extension Addendum.
 
 ### Data Access Committee
 

--- a/docs/guides/data/command-line.md
+++ b/docs/guides/data/command-line.md
@@ -73,7 +73,7 @@ user has selected the Rapid RNA-Seq tool.
 Moving data back and forth between the cloud and your local computer is
 simple once you have selected the correct project for your tool.
 
-You will find that many common linux commands with `#!python dx` prepended.
+You will find that many common Linux commands with `#!python dx` prepended.
 
 ```bash
 # list available files for the tool for the main folder

--- a/docs/guides/data/data-request.md
+++ b/docs/guides/data/data-request.md
@@ -17,7 +17,7 @@ environment.
     If you would like to download the data to local storage, there are
     extra steps you'll need to follow such as [getting additional signatures](../../guides/forms/how-to-fill-out-DAA#data-download-permission)
     on your data access agreement. We recommend that you work with the data
-    in the cloud if it's feasible; the data provided by St. Jude is free, the compute charges are reasonable, and working in the cloud helps to eliminate the long, error-prone downloading process. Porting your tools to be run in the cloud is easy, as well. We recommend you follow [this guide](../../guides/data/run-your-tools) to get started.
+    in the cloud if it's feasible; the data provided by St. Jude is free, the compute charges are reasonable, and working in the cloud helps to eliminate the long, error-prone downloading process. Porting your tools to be run in the cloud is easy, as well. We recommend you follow [this guide](../../guides/data/creating-a-cloud-app) to get started.
 
 ## Selecting Data
 

--- a/docs/guides/data/data-request.md
+++ b/docs/guides/data/data-request.md
@@ -84,7 +84,7 @@ This will direct you to the [Manage Data](https://platform.stjude.cloud/requests
 
 ![](../../images/guides/data/request-data-new-2.png)
 
-If you already have access to the data that you requested, your data will be vended to you immediately. Otherwise, the status of your request will say *Pending* while your request is routed to the respective [Data Access Committee(s)](../../glossary.md#data-access-committee) for evaluation. Request approval typically takes a week or two if your data access agreement is correctly and completely filled out. You will receive automated emails from notifications@stjude.cloud at the time that your request is recieved and once your request is approved.
+If you already have access to the data that you requested, your data will be vended to you immediately. Otherwise, the status of your request will say *Pending* while your request is routed to the respective [Data Access Committee(s)](../../glossary.md#data-access-committee) for evaluation. Request approval typically takes a week or two if your data access agreement is correctly and completely filled out. You will receive automated emails from notifications@stjude.cloud at the time that your request is received and once your request is approved.
 
 !!! note 
     If you receive an email from us that your DAA is incomplete, you may edit your DAA and upload the revised copy using the 'Add a Form' button the on Manage Data page. 

--- a/docs/guides/forms/how-to-fill-out-Extension.md
+++ b/docs/guides/forms/how-to-fill-out-Extension.md
@@ -4,7 +4,7 @@ The St. Jude Cloud [Data Access Agreement (DAA)](../../glossary.md#data-access-a
 
 In order to extend your DAA, you must fill out an Extension Addendum. The Extension Addendum will extend the previous agreement for an additional year. Please note that if you do not fill out an Extension Addendum, you will be expected to delete all copies of the data subject to the expiring agreement.
 
-Follow the steps below to ensure that you have acurately filled out all sections of the Extension Addendum.
+Follow the steps below to ensure that you have accurately filled out all sections of the Extension Addendum.
 
 1. **Page 1**
     * In the top section, enter the current date on which that the agreement is being filled out, your current institution, and the date on which you signed the expiring DAA or extension.
@@ -41,6 +41,6 @@ Once you have finished filling out the Extension Addendum, you may upload the co
 
 ### Frequently Asked Questions
 
-**Q. What if I did not fill out the Data Download Permission section of the origianl DAA, but now I want to download data?**
+**Q. What if I did not fill out the Data Download Permission section of the original DAA, but now I want to download data?**
 
 **A.** Since this would be a change in terms from the original agreement, you would need to fill out a new DAA (including the Data Download Permission section) for any datasets you want to download.

--- a/docs/guides/portals/genome-paint.md
+++ b/docs/guides/portals/genome-paint.md
@@ -11,7 +11,7 @@ The GenomePaint browser homepage lands on a dense cohort view of the TAL1 gene r
 To navigate tracks,
 
 * Pan left or right by clicking on the middle part of the track and dragging
-* Zoom in by draging on the genomic coordinate ruler on top or zoom in 1 fold by clicking on the **IN** button
+* Zoom in by dragging the genomic coordinate ruler on top or zoom in 1 fold by clicking on the **IN** button
 * Zoom out by *x* fold by clicking on an **OUT** button.
 
 ![](../../images/guides/portals/genome-paint/navigation.gif)
@@ -39,7 +39,7 @@ The sample view shows mutations for one sample alone, along with any available g
 
 ![](../../images/guides/portals/genome-paint/sample_view.gif)
 
-On the sample view you can explore expression rank, tumor mutations, structural variants, splice junctions, WES coverage, and RNA-Seq coverage. Customize the display by zooming in/out, hiding and/or rearraging tracks, or editing **CONFIG** options.
+On the sample view you can explore expression rank, tumor mutations, structural variants, splice junctions, WES coverage, and RNA-Seq coverage. Customize the display by zooming in/out, hiding and/or rearranging tracks, or editing **CONFIG** options.
 
 ## Matrix View
 The matrix view combines the mutation profiles of multiple genomic regions in one view, in the form of a sample-by-region matrix. Such a matrix can be generated for samples from one cancer type. To open a matrix view, select a disease cohort from the cohort view and then select Matrix view. This organizes the selected cohort tumors with mutations in the genomic region you are viewing into a single-column matrix.

--- a/docs/guides/portals/pecan.md
+++ b/docs/guides/portals/pecan.md
@@ -54,7 +54,7 @@ The list below summarizes all classes of mutations used by ProteinPaint.
 | NONSENSE	| a variant altering protein coding to produce a premature stopgain or stoploss.|
 | PROTEINDEL	| a deletion resulting in a loss of one or more codons from the product, but not altering the protein coding frame |
 |PROTEININS	| an insertion introducing one or more codons into the product, but not altering the protein coding frame|
- | SPLICE	| a variant near an exon edge that may affect splicing functionality |
+| SPLICE	| a variant near an exon edge that may affect splicing functionality |
 | SILENT	| a substitution variant in the coding region that does not alter protein coding |
 | SPLICE_REGION	| a variant in an intron within 10 nt of an exon boundary |
 | UTR_5	| a variant in the 5' untranslated region |

--- a/docs/guides/portals/pecan.md
+++ b/docs/guides/portals/pecan.md
@@ -2,11 +2,11 @@
 PeCan provides interactive visualizations of pediatric cancer mutations across various projects at St. Jude Children's Research Hospital and its collaborating institutions.
 
 ## Homepage 
-The [PeCan homepage](https://pecan.stjude.cloud/home) contains two main visualizations that work with each other to give a high level overview of the data being presented (SJ Cloud's [PCGP](../glossary/data-access-unit#pediatric-cancer-genome-project-(pcgp)) dataset along with curated datasets from other instiutions such as [TARGET](https://ocg.cancer.gov/programs/target), [dkfz](https://www.dkfz.de/en/index.html), and others).
+The [PeCan homepage](https://pecan.stjude.cloud/home) contains two main visualizations that work with each other to give a high level overview of the data being presented (SJ Cloud's [PCGP](../../glossary#pediatric-cancer-genome-project-pcgp) dataset along with curated datasets from other institutions such as [TARGET](https://ocg.cancer.gov/programs/target), [dkfz](https://www.dkfz.de/en/index.html), and others).
 
 
 ### Donut Chart
-The donut chart (shown below) gives an at-a-glance disease distribution and disease heiarchy. 
+The donut chart (shown below) gives an at-a-glance disease distribution and disease hierarchy. 
 
 ![](../../images/guides/portals/pecan/home_donut.png)
 
@@ -17,7 +17,7 @@ You can hover over the various donut slices to glance at the number (and %) of s
 ### Bubble Chart
 Any slice (at any level) of the donut chart can be clicked on to select it, and reveal a bubble chart of related genes. 
 
-Note that the dataset bar (shown below) on top of the bubble chart visualizes the distribution of selected data across the datsets used in this visualization. It will update dynamically as you interact with the donut chart and make different selctions.
+Note that the dataset bar (shown below) on top of the bubble chart visualizes the distribution of selected data across the datasets used in this visualization. It will update dynamically as you interact with the donut chart and make different selections.
 
 ![](../../images/guides/portals/pecan/dataset_dist_bar.png)
 

--- a/docs/guides/portals/sickle-cell.md
+++ b/docs/guides/portals/sickle-cell.md
@@ -1,4 +1,4 @@
-The Sickle Cell Genomics Portal contains two viewers for the exploration of data from the  [Sickle Cell Genome Project (SGP)](../glossary/data-access-unit#sickle-cell-genome-project-(sgp)) dataset.
+The Sickle Cell Genomics Portal contains two viewers for the exploration of data from the  [Sickle Cell Genome Project (SGP)](../glossary/data-access-unit#sickle-cell-genome-project-sgp) dataset.
 
 ## Genome Browser
 

--- a/docs/guides/portals/sickle-cell.md
+++ b/docs/guides/portals/sickle-cell.md
@@ -13,7 +13,7 @@ A description of the elements of the browser are as follows:
 | 1| Navigation tools and track selector. ([See Navigation Buttons section](#navigation-buttons))  | 
 |2|    DNase hypersensitivity tracks.  By default, four epigenetic tracks are shown.  These are DNAse hypersensitivity tracks for Hematopoeitic stem cells (HSC), T Cells, Monocytes, and B Cells.  Additional tracks can be viewed by selecting the ‘Tracks’ button (See Adding/Removing Tracks section below)  |  
 |3 | RefSeq genes.  Gene models from the RefSeq database are displayed in this tracks. | 
-|4 |-log10 of the p-value of the association of each variants with pain rate in individuals with Sickle Cell Disease.  The analysis has only been performed around the  KIAA1109/Tenr/IL2/IL21 region.   Each dot on the track represents a genomic variant (Single Nucleotide Variant (SNV) or small insertion/deletion (INDEL)).  The Y-axis for the track represents the -log10 of the p-value.  The higher the value, the more stastically significant the association between the variant and pain rate is.  Clicking on a variant will open op a window that gives further details about the variant.  (See Figure 3). | 
+|4 |-log10 of the p-value of the association of each variants with pain rate in individuals with Sickle Cell Disease.  The analysis has only been performed around the  KIAA1109/Tenr/IL2/IL21 region.   Each dot on the track represents a genomic variant (Single Nucleotide Variant (SNV) or small insertion/deletion (INDEL)).  The Y-axis for the track represents the -log10 of the p-value.  The higher the value, the more statistically significant the association between the variant and pain rate is.  Clicking on a variant will open op a window that gives further details about the variant.  (See Figure 3). | 
 |5 | -log10 of the p-value of the association of each variants with age of first vaso-occlusive crisis in individuals with Sickle Cell Disease.  See (4) above for more information on this type of track. | 
 |6| Filters: Filters allow variants within tracks to be filtered by numerous citeria.  [See Filter description](#filters)|
 
@@ -39,7 +39,7 @@ A description of the elements of the browser are as follows:
 | a| Filters for pain rate p-value track | 
 |b|  Filters for age of first vaso-occlusive crisis (VOC) p-value |  
 |c | The highlighted filter shows which value is  used for the Y-axis on the browser track.  The value can be changed. | 
-|d | A highligthed value within a filter shows which filter value is set.  The number next to the filter represents the number of individuals that meet the filter criteria.| 
+|d | A highlighted value within a filter shows which filter value is set.  The number next to the filter represents the number of individuals that meet the filter criteria.| 
 
 
 ### Getting Started
@@ -76,7 +76,7 @@ One can scroll down to see additional tracks.  Try selecting and unselecting var
 #### Getting DNA sequence
 Select the 'More' button at the top of the browser.
 ![](../../images/guides/portals/sickle-cell/more.png)
-Several options will be avaialble.  Select the DNA sequence button.
+Several options will be available.  Select the DNA sequence button.
 ![](../../images/guides/portals/sickle-cell/DNASequenceCircled.png)
 You will be shown the DNA sequence for the region.
 ![](../../images/guides/portals/sickle-cell/DNASequenceShown.png)
@@ -96,7 +96,7 @@ The different elements of the view are as follows.
 | 1| Settings and sort buttons.  In addition a link to this help document. | 
 |2|  Legend for different tracks in the viewer |  
 |3 | Phenotypic data displayed with an individual represented in each column | 
-|4 | Gentoypic data displayed with an individual represented in each column | 
+|4 | Genotypic data displayed with an individual represented in each column | 
 
 ### Labels
 [See glossary for further details](#glossary)
@@ -122,7 +122,7 @@ The following graph shows individuals sorted by MCV.  Blank columns represent no
 ![](../../images/guides/portals/sickle-cell/PhenoVariantPainSorted.png)
 
 #### View values for all patients
-Hovering over one column will enable the viewing of all  phenotypic values for that patient.
+Hovering over one column will enable the viewing of all phenotypic values for that patient.
 
 #### Undo
 While exploring the data, one may inadvertently sort or remove data.  One can undo the changes by selecting the undo button at the top of the viewer.  The redo button will revert the undo.
@@ -133,9 +133,9 @@ While exploring the data, one may inadvertently sort or remove data.  One can un
 <a name="hbf"></a>
 
 * **Fetal hemoglobin (HbF)**
-Fetal hemoglobin contains two subunits of gamma-globin and two units of alpha-globin, while adult hemoglobin contains two subuints of beta-globin and two units of alpha-globin. 
+Fetal hemoglobin contains two subunits of gamma-globin and two units of alpha-globin, while adult hemoglobin contains two subunits of beta-globin and two units of alpha-globin. 
 
-* **Heriditary persistance of fetal hemoglobin (HPFH)**
+* **Heriditary persistence of fetal hemoglobin (HPFH)**
 Individuals with HPFH have elevated levels of fetal hemoglobin. These elevated levels reduce or eliminate many of the symptoms of Sickle Cell Disease.
 
 * **Principal Component Analysis (PCA)**

--- a/docs/guides/tools/neoepitope.md
+++ b/docs/guides/tools/neoepitope.md
@@ -34,7 +34,7 @@ Genome Project[^1].
 | Name | Description |
 |--|--|
 | Epitope affinity prediction (html) | Epitope affinity. The peptide with affinity &lt; cutoff will be highlighted. |
-| Epitope affinity prediction (xlsx) | Excel tables for the infomation of all epitopes |
+| Epitope affinity prediction (xlsx) | Excel tables for the information of all epitopes |
 | Affinity (raw output) | Epitope affinity |
 | Peptide sequence (raw output) | Peptide sequences in Fasta format |
 
@@ -299,7 +299,7 @@ The following columns will be shown in the output:
 | Sample | the name of the samples |
 | Chromosome (chr) | the chromosome location of the variation |
 | Position | the chromosomal position of the variation. Currently, the position will be lifted over to HG19 to ensure correct translation of peptid sequences based on the internal annotation database of the pipeline. Therefore, the position will be labeled as HG19. |
-| Class | class of the varitaion |
+| Class | class of the variation |
 | Reference allele | reference allele at the position |
 | Mutant allele | mutated allele at the position |
 | mRNA_acc | NCBI accession number of the mRNA |

--- a/docs/guides/tools/pecan-pie.md
+++ b/docs/guides/tools/pecan-pie.md
@@ -16,7 +16,7 @@ may predispose individuals to cancer. It is free for non-commercial use.
 
 Pecan PIE utilizes St. Jude Medal Ceremony, the same pipeline that
 powers our clinical and research genomics projects. Medal Ceremony
-provides a 3-level ranking of putative pathogenity - Gold, Silver or
+provides a 3-level ranking of putative pathogenicity - Gold, Silver or
 Bronze - for mutations within disease-related genes. Medal assignment is
 based on matches to 22 mutation databases, mutation type, population
 frequency, tumor suppressor status and predicted functional impact. The

--- a/docs/guides/tools/warden.md
+++ b/docs/guides/tools/warden.md
@@ -414,7 +414,7 @@ Several files should be examined initially to determine the quality of
 the results. **alignmentStatistics.txt** shows alignment statistics for
 all samples. This file is a plain text tab-delimited file that can be
 opened in Excel or a text editor such as Notepad++. This file contains
-information on the total reads per sample, the percantage of duplicate
+information on the total reads per sample, the percentage of duplicate
 reads and the percentage of mapped reads. An example of this file is
 below. (Within the DNAnexus output directory structure, these files will
 be in the COMBINED\_FLAGSTAT directory.)
@@ -450,13 +450,13 @@ allow the viewing of these files off of DNAnexus.)
 
 **LIMMA differential expression viewer**
 
-Within LIMMA/VIEWERS direcory (note if no comparisons meet the 3 sample
+Within LIMMA/VIEWERS directory (note if no comparisons meet the 3 sample
 condition, the LIMMA folder will not exist), there will be a viewer file
 for each valid comparison ( \**results.*.txt.viewer\*\*). Simply select
 the file and press 'Launch viewer' in the lower right. A viewer will pop
 up showing both the MA Plot and Volcano plot. By moving the mouse over a
-circle, the circle will hilight and the corresponding gene on the other
-graph will also hilight. Additional information about the gene and its
+circle, the circle will highlight and the corresponding gene on the other
+graph will also highlight. Additional information about the gene and its
 expression values will also be shown. One can also type in multiple gene
 symbols in the provided text box. By pressing 'Show gene labels' all
 these genes will show up on the plots.
@@ -465,7 +465,7 @@ these genes will show up on the plots.
 
 **Simple differential expression viewer**
 
-There will also be a viewer for the simple differential expresssion
+There will also be a viewer for the simple differential expression
 analysis in SIMPLE\_DIFEX/VIEWERS. The P-value for the results have all
 been set to 1, so the volcano plot will not be relevant.
 
@@ -493,11 +493,11 @@ Other useful differential expression results will be downloaded by the desktop a
 Input files that can be used for GSEA analysis. The tStat file is preferred for a more accurate analysis, but will not give a heatmap diagram.
 - (Within the DNAnexus output directory structure, these files will be in the LIMMA directory.)
 
-- For plain text results from the simple differential expresison analysis, the files will be named `simpleDE.*.txt`. (Within the DNAnexus output directory structure, these files will be in the SIMPLE\_DIFEX directory.)
+- For plain text results from the simple differential expression analysis, the files will be named `simpleDE.*.txt`. (Within the DNAnexus output directory structure, these files will be in the SIMPLE\_DIFEX directory.)
 
 - Prelabelled MA and volcano plots are provided for the analysis. These files are labeled `maPlot.*.png` and `volcanoPlot.*.png` where `*` is the comparison (e.g. ko\_vs\_wt)
 
-- The MA plot shows the average expression of the gene on the X-axis, and Log2 fold change between condition/phenotype is on the Y-axis (if the name is for example maPlot.condition2-condition1.png then the fold change would represent condition1 minus condition2). Each gene is represented by a circle. The top 20 genes (by p-value) are identified on the plot. The genes are color coded by the chosen multiple testing correction method (False Discovery Rate (FDR) by default. An exmaple MA plot can be seen below. (Within the DNAnexus output directory structure, these files will be in the LIMMA directory.)
+- The MA plot shows the average expression of the gene on the X-axis, and Log2 fold change between condition/phenotype is on the Y-axis (if the name is for example maPlot.condition2-condition1.png then the fold change would represent condition1 minus condition2). Each gene is represented by a circle. The top 20 genes (by p-value) are identified on the plot. The genes are color coded by the chosen multiple testing correction method (False Discovery Rate (FDR) by default. An example MA plot can be seen below. (Within the DNAnexus output directory structure, these files will be in the LIMMA directory.)
 
 ![](../../images/guides/tools/warden/maPlot.png)
 
@@ -536,9 +536,9 @@ the SIMPLE\_DIFEX directory.)
 **Coverage results**
 
 bigWig files will be generated for use in genome browsers (such as IGV
-<http://software.broadinstitute.org/software/igv/>). For each smaple,
+<http://software.broadinstitute.org/software/igv/>). For each sample,
 multiple bigWig files will be found. For all types of sequencing
-strandedness, there will be bigWig files labelled,
+strandedness, there will be bigWig files labeled,
 **\*.sortedCoverageFile.bed.bw** where '*' is the sample name. For
 stranded data there will also be\*.sortedPosCoverageFile.bed.bw*\* and
 **\*.sortedNegCoverageFile.bed.bw** which contains coverage information
@@ -550,7 +550,7 @@ the BIGWIG directory.)
 -----------------
 **Quality Control Results (FastQC)**
 
-Within the FastQC directory, foreach sample and read direction there
+Within the FastQC directory, for each sample and read direction there
 will be an html file and a zip file (**\*.FastQc.html**
 **\*.FastQc.zip** where '\*' is the base FastQ name), containing results
 from FastQTC. For the average user the html file is sufficient. This
@@ -578,8 +578,8 @@ the ALIGN directory.)
 Additional files created by STAR are provided. More information on these
 files can be found at
 <http://labshare.cshl.edu/shares/gingeraslab/www-data/dobin/STAR/STAR.posix/doc/STARmanual.pdf>.
-**\*.SJ.out.tab** contain splice junction information. Fusion detectino
-files are labelled **\*.Chimeric.out.bam** and
+**\*.SJ.out.tab** contain splice junction information. Fusion detection
+files are labeled **\*.Chimeric.out.bam** and
 **\*.Chimeric.out.junction**.
 
 (Within the DNAnexus output directory structure, these files will be in
@@ -604,7 +604,7 @@ documentation can be found in **methods.txt**
 (Within the DNAnexus output directory structure, these files will be in
 the METHODS directory.)
 
-#### Auxilary Files
+#### Auxiliary Files
 
 This section describes the files that exist within the DNAnexus output
 folder. Most of these files will not be of interest to the average user.
@@ -628,8 +628,8 @@ The following description of files is sorted by their output directory.
 This directory contains the BAM files described in [BAM alignment
 files](#bam-alignment-files) and the chimeric and junction files are
 described in [Chimeric reads and junction
-files](#chimeric-reads-and-junction-files). In adition there are 2 log
-files. **\*Log.final.out** has relevant statistics for the alignemnt.
+files](#chimeric-reads-and-junction-files). In addition there are 2 log
+files. **\*Log.final.out** has relevant statistics for the alignment.
 The **\*.Log.out** file just contains a log of the analysis run,
 including input parameters. Per sample FLAGSTAT results are found in
 **\*.flagStatOut.txt**. These flagstat files are combined into the file

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ St. Jude shares a number of end-to-end analysis workflows on the cloud. Click on
 * [ChIP-Seq Peak Calling](https://platform.stjude.cloud/tools/chip-seq)
 * [Rapid RNA-Seq Fusion Detection](https://platform.stjude.cloud/tools/rapid_rna-seq)
 * [WARDEN Differential Expression Analysis](https://platform.stjude.cloud/tools/warden)
-* [Mutational Signatures](https://platform.stjude.cloud/tools/mutational_spectrum)
+* [Mutational Signatures](https://platform.stjude.cloud/tools/mutational_signatures)
 * cis-x (coming soon)
 * XenoCP (coming soon)
 


### PR DESCRIPTION
This commit adds the missing client_id url parameter to the login links. It also fixes the incorrect relative links in various pages of the documentation such as the links to filling out the forms from the glossary page. It also contains corrections for spelling on several pages.