### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: 'St. Jude Cloud Documentation'
+site_url: 'https://www.stjude.cloud/docs/'
 theme:
   name: 'material'
   custom_dir: 'mkdocs-material/material'


### PR DESCRIPTION
added the built in fuction, site_url, in order to set the canonical URK of the site to 'https://www.stjude.cloud/docs/'.