### PR TITLE
Kirby requested edits to Paint pages and DAA instructions

### DIFF
--- a/docs/guides/forms/how-to-fill-out-DAA.md
+++ b/docs/guides/forms/how-to-fill-out-DAA.md
@@ -15,7 +15,7 @@ Next, ensure that you have correctly filled out the 5 required sections of the D
      ![](../../images/guides/forms/daa-1.png)
 
 2. **Page 6** Signature and information of the Principal Investigator.
-    * A Principal Investigator (PI) is designated by the grantee organization to direct the project or activity being supported by the grant. The PI is responsible and accountable to the grantee for the proper conduct of the project or activity. The role of the PI within the eRA Commons is to complete the grant process, either by completing the required forms via the eRA Commons or by delegating this responsibility to another individual. A PI can access information for any grant for which they are designated the PI. See eRA Commons Roles & Privileges Matrix. Typically the PI signee is the faculty-level supervisor on the project.
+    * A Principal Investigator (PI) is designated by the grantee organization to direct the project or activity being supported by the grant. The PI is responsible and accountable to the grantee for the proper conduct of the project or activity. The role of the PI within the eRA Commons is to complete the grant process, either by completing the required forms via the eRA Commons or by delegating this responsibility to another individual. A PI can access information for any grant for which they are designated the PI. See eRA Commons Roles & Privileges Matrix. Typically the PI signee is the faculty-level supervisor on the project, but it is not a requirement.
 
     ![](../../images/guides/forms/daa-2.png)
 

--- a/docs/guides/forms/how-to-fill-out-DAA.md
+++ b/docs/guides/forms/how-to-fill-out-DAA.md
@@ -15,7 +15,7 @@ Next, ensure that you have correctly filled out the 5 required sections of the D
      ![](../../images/guides/forms/daa-1.png)
 
 2. **Page 6** Signature and information of the Principal Investigator.
-    * This must be signed by a Principal Investigator or a faculty-level supervisor on the project.
+    * A Principal Investigator (PI) is designated by the grantee organization to direct the project or activity being supported by the grant. The PI is responsible and accountable to the grantee for the proper conduct of the project or activity. The role of the PI within the eRA Commons is to complete the grant process, either by completing the required forms via the eRA Commons or by delegating this responsibility to another individual. A PI can access information for any grant for which they are designated the PI. See eRA Commons Roles & Privileges Matrix. Typically the PI signee is the faculty-level supervisor on the project.
 
     ![](../../images/guides/forms/daa-2.png)
 

--- a/docs/guides/portals/genome-paint.md
+++ b/docs/guides/portals/genome-paint.md
@@ -52,6 +52,6 @@ Next, go back to the cohort view and type another gene or region of interest int
 
 This will add the new genomic variant as a second column in the matrix. You can continue adding columns to this matrix in the same manner.
 
+## Advanced Customizations
 
-!!! note
-    A detailed tutorial for GenomePaint can be found [here](https://docs.google.com/document/d/1owXUQuqw5hBHFERm0Ria7anKtpyoPBaZY_MCiXXf5wE/edit). You'll also find instructions to create custom tracks, visualize your own data, and embed images on your web page. Please excuse the different location and formatting as we work to incorporate this into our main documentation pages. 
+There are several more advanced customizations you can leverage with GenomePaint such as creating custom tracks, importing your own data, and embedding interactive visualizations on your web page. For instructions on these topics, please see our [detailed tutorial](https://docs.google.com/document/d/1owXUQuqw5hBHFERm0Ria7anKtpyoPBaZY_MCiXXf5wE/edit). Please excuse the different location and formatting as we work to incorporate this into our main documentation pages.

--- a/docs/guides/portals/pecan.md
+++ b/docs/guides/portals/pecan.md
@@ -40,8 +40,6 @@ The image below shows an example ProteinPaint of the gene [TP53](https://pecan.s
 
 ![](../../images/guides/portals/pecan/protein_paint_overview.png)
 
-!!! note
-    A detailed tutorial for ProteinPaint can be found [here](https://docs.google.com/document/d/1JWKq3ScW62GISFGuJvAajXchcRenZ3HAvpaxILeGaw0/edit). Please excuse the different location and formatting as we work to incorporate this into our main documentation pages. 
 
 ### Glossary of Classes 
 
@@ -71,6 +69,10 @@ The list below summarizes all origins of mutations used by ProteinPaint.
 | Germline	|a variant found in a normal sample of a cancer patient. |
 | Somatic	| a variant found only in a tumor sample. |
 | Relapse	| a variant that arose in recurrence tumor. |
+
+### Advanced Customizations
+
+There are several more advanced customizations you can leverage with ProteinPaint such as creating custom tracks, importing your own data, and embedding interactive visualizations on your web page. For instructions on these topics, please see our [detailed tutorial](https://docs.google.com/document/d/1JWKq3ScW62GISFGuJvAajXchcRenZ3HAvpaxILeGaw0/edit). Please excuse the different location and formatting as we work to incorporate this into our main documentation pages.
 
 
 ## Studies


### PR DESCRIPTION
-added verbage in the DAA PI section to specify more stringent conditions for who a PI signee can  and cannot be.
-added a section to more clearly exposure to the user instructions for advanced customization for GenomePaint
-added a section to more clearly exposure to the user instructions for advanced customization for ProteinPaint