### PR TITLE
guides/data: Redirect metadata to about-our-data

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,6 +30,7 @@ dependencies:
     - markupsafe==1.1.1
     - mkdocs==1.1
     - mkdocs-material==4.6.3
+    - mkdocs-redirects==1.0.1
     - nltk==3.4.5
     - pygments==2.6.1
     - pymdown-extensions==7.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,11 @@ theme:
 extra_css:
   - css/extra.css
 
+plugins:
+  - redirects:
+      redirect_maps:
+        'guides/data/metadata': 'guides/genomics-platform/requesting-data/about-our-data.md'
+
 nav:
   - Overview: index.md
   - About our Ecosystem: ecosystem.md
@@ -61,7 +66,7 @@ nav:
     - Childhood Solid Tumor Network Portal: guides/cstn.md
     - Pediatric Brain Tumor Portal: guides/pbtp.md
   - ProteinPaint:
-    - ProteinPaint: 
+    - ProteinPaint:
         - Introduction: guides/proteinpaint/index.md
         - User Guide:
             - Getting Started: guides/proteinpaint/navigating-the-protein-diagram.md


### PR DESCRIPTION
This redirects the old metadata documentation to the correct page.